### PR TITLE
added logic to avoid adding CORRECT_PATH_SEPARATOR_S when not needed.

### DIFF
--- a/src/menu/chatsystem.cpp
+++ b/src/menu/chatsystem.cpp
@@ -50,8 +50,11 @@ bool Menu::CChatSystem::Load(const char *pszBaseGameDir, const char *pszPathID, 
 	AnyConfig::LoadFromFile_Generic_t aLoadPresets({{&sError, NULL, pszPathID}, g_KV3Format_Generic});
 
 	{
-		sConfigFile.Insert(0, pszBaseGameDir);
-		sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+		if (strlen(pszBaseGameDir) > 0)
+		{
+			sConfigFile.Insert(0, pszBaseGameDir);
+			sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+		}
 		sConfigFile.Insert(sConfigFile.Length(), MENU_CHATSYSTEM_ALIASES_FILENAME);
 
 		const char *pszConfigFile = sConfigFile.Get();

--- a/src/menu/profilesystem.cpp
+++ b/src/menu/profilesystem.cpp
@@ -52,8 +52,12 @@ bool Menu::CProfileSystem::Load(const char *pszBaseGameDir, const char *pszPathI
 	AnyConfig::LoadFromFile_Generic_t aLoadPresets({{&sError, NULL, pszPathID}, g_KV3Format_Generic});
 
 	{
-		sConfigFile.Insert(0, pszBaseGameDir);
-		sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+		if (strlen(pszBaseGameDir) > 0)
+		{
+			sConfigFile.Insert(0, pszBaseGameDir);
+			sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+		}
+
 		sConfigFile.Insert(sConfigFile.Length(), MENU_SYSTEM_PROFILES_FILENAME);
 
 		const char *pszConfigFile = sConfigFile.Get();

--- a/src/menu/provider.cpp
+++ b/src/menu/provider.cpp
@@ -167,8 +167,13 @@ bool Menu::CProvider::CGameDataStorage::Load(IGameData *pRoot, const char *pszBa
 	for(const auto &aConfig : aConfigs)
 	{
 		sConfigFile.Clear();
-		sConfigFile.Insert(0, pszBaseGameDir);
-		sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+
+		if (strlen(pszBaseGameDir)>0)
+		{
+			sConfigFile.Insert(0, pszBaseGameDir);
+			sConfigFile.Insert(sConfigFile.Length(), CORRECT_PATH_SEPARATOR_S);
+		}
+
 		sConfigFile.Insert(sConfigFile.Length(), aConfig.pszFilename);
 
 		const char *pszConfigFile = sConfigFile.Get();

--- a/src/menusystem_plugin.cpp
+++ b/src/menusystem_plugin.cpp
@@ -2728,7 +2728,12 @@ bool MenuSystem_Plugin::UnregisterNetMessages(char *error, size_t maxlen)
 
 bool MenuSystem_Plugin::ParseLanguages(char *error, size_t maxlen)
 {
-	std::string sTranslationsFilesPath = m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S MENUSYSTEM_GAME_LANGUAGES_FILES;
+	std::string sTranslationsFilesPath = "";
+	if (m_sBaseGameDirectory.length() > 0)
+		sTranslationsFilesPath.append(m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S);
+
+	sTranslationsFilesPath.append(MENUSYSTEM_GAME_LANGUAGES_FILES);
+
 
 	const char *pszPathID = MENUSYSTEM_BASE_PATHID, 
 	           *pszLanguagesFiles = sTranslationsFilesPath.c_str();
@@ -2840,7 +2845,11 @@ bool MenuSystem_Plugin::ClearLanguages(char *error, size_t maxlen)
 
 bool MenuSystem_Plugin::ParseTranslations(char *error, size_t maxlen)
 {
-	std::string sTranslationsFilesPath = m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S MENUSYSTEM_GAME_TRANSLATIONS_FILES;
+	std::string sTranslationsFilesPath = "";
+	if (m_sBaseGameDirectory.length() > 0)
+		sTranslationsFilesPath.append(m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S);
+
+	sTranslationsFilesPath.append(MENUSYSTEM_GAME_TRANSLATIONS_FILES);
 
 	const char *pszPathID = MENUSYSTEM_BASE_PATHID, 
 	           *pszTranslationsFiles = sTranslationsFilesPath.c_str();
@@ -2908,7 +2917,11 @@ bool MenuSystem_Plugin::ParseTranslations(char *error, size_t maxlen)
 
 bool MenuSystem_Plugin::ParseTranslations2(char *error, size_t maxlen)
 {
-	std::string sTranslationsDirsPath = m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S MENUSYSTEM_GAME_TRANSLATIONS_COUNTRY_CODES_DIRS;
+	std::string sTranslationsDirsPath = "";
+	if (m_sBaseGameDirectory.length() > 0)
+		sTranslationsDirsPath.append(m_sBaseGameDirectory + CORRECT_PATH_SEPARATOR_S);
+	
+	sTranslationsDirsPath.append(MENUSYSTEM_GAME_TRANSLATIONS_COUNTRY_CODES_DIRS);
 
 	const char *pszPathID = MENUSYSTEM_BASE_PATHID, 
 	           *pszTranslationsDirs = sTranslationsDirsPath.c_str();
@@ -2944,7 +2957,11 @@ bool MenuSystem_Plugin::ParseTranslations2(char *error, size_t maxlen)
 
 		if(g_pFullFileSystem->IsDirectory(pszDirectory, pszPathID))
 		{
-			std::string sTranslationsFilesPath = std::string(pszDirectory) + CORRECT_PATH_SEPARATOR_S MENUSYSTEM_GAME_TRANSLATIONS_FILENAMES;
+			std::string sTranslationsFilesPath = "";
+			if (strlen(pszDirectory) > 0)
+				sTranslationsFilesPath.append(std::string(pszDirectory) + CORRECT_PATH_SEPARATOR_S);
+
+			sTranslationsFilesPath.append(MENUSYSTEM_GAME_TRANSLATIONS_FILENAMES);
 
 			const char *pszTranslationsFiles = sTranslationsFilesPath.c_str();
 


### PR DESCRIPTION
Added logic to avoid adding CORRECT_PATH_SEPARATOR_S when not needed.

Windows at least does not like this and has fits, only tested on my system but resolves the suffix / prefix concatenation warnings.